### PR TITLE
Support additional DomScenes in Scene

### DIFF
--- a/src/display/Scene.coffee
+++ b/src/display/Scene.coffee
@@ -149,22 +149,22 @@ class SceneDOM extends Composable
 
       @domElement.style.display = 'flex'
 
-      mkLayer = (name) =>
-        layer = document.createElement 'div'
-        layer.style.position = 'absolute'
-        layer.style.margin   = 0
-        layer.style.width    = '100%'
-        layer.style.height   = '100%'
-        layer.id = @domElement.id + '-layer-' + name
-        @domElement.appendChild layer
-        layer
-
-      @domLayer   = mkLayer 'dom'
-      @glLayer    = mkLayer 'gl'
-      @statsLayer = mkLayer 'stats'
+      @domLayer   = @addLayer 'dom'
+      @glLayer    = @addLayer 'gl'
+      @statsLayer = @addLayer 'stats'
 
       @glLayer    . style.pointerEvents = 'none'
       @statsLayer . style.pointerEvents = 'none'
+
+  addLayer: (name) =>
+    layer = document.createElement 'div'
+    layer.style.position = 'absolute'
+    layer.style.margin   = 0
+    layer.style.width    = '100%'
+    layer.style.height   = '100%'
+    layer.id = @domElement.id + '-layer-' + name
+    @domElement.appendChild layer
+    layer
 
   refreshSize: () ->
     @geometry.resize @domElement.clientWidth, @domElement.clientHeight

--- a/src/display/Scene.coffee
+++ b/src/display/Scene.coffee
@@ -219,9 +219,10 @@ export class Scene extends Composable
     @_dom            = @mixin SceneDOM, cfg
     @_autoUpdate     = true
     @_camera         = new Camera
-    modeCfg          = extend cfg, {camera: @_camera}
-    @_symbolModel    = new SceneModel modeCfg
-    @_domModel       = new SceneModel modeCfg
+    @_modeCfg        = extend cfg, {camera: @_camera}
+    @_symbolModel    = new SceneModel @_modeCfg
+    @_domModel       = new SceneModel @_modeCfg
+    @_scenes         = [@_symbolModel, @_domModel]
     @_symbolRegistry = new SymbolRegistry @_symbolModel.model
     @configure cfg
     @_creationTime   = Date.now()
@@ -232,6 +233,11 @@ export class Scene extends Composable
 
     @_stats = new Stats
 
+  addDOMScene: =>
+    newScene = new SceneModel @_modeCfg
+    newScene._renderer = @initDomRenderer()
+    @_scenes.push newScene
+    newScene
 
   init: ->
     #TODO: make mixin initialization postponed to this moment!
@@ -319,8 +325,8 @@ export class Scene extends Composable
 
   onResized: () ->
     @initSymbolPointerBuffers()
-    @symbolModel . setSize @width, @height
-    @domModel    . setSize @width, @height
+    for scene in @scenes
+      scene . setSize @width, @height
     @camera.adjustToScene @
 
   requestIDScreenshot: (callback) ->
@@ -349,8 +355,8 @@ export class Scene extends Composable
     @symbolRegistry.materials.uniforms.zoom       = @camera.position.z
     @symbolRegistry.materials.uniforms.time       = Date.now() - @_beginTime
     @symbolRegistry.materials.uniforms.drawBuffer = DRAW_BUFFER.NORMAL
-    @symbolModel.render()
-    @domModel.render()
+    for scene in @scenes
+      scene.render()
     if @onscreen then @handleMouse()
 
   handleMouse: ->

--- a/src/display/Symbol.coffee
+++ b/src/display/Symbol.coffee
@@ -181,7 +181,7 @@ class DOMSymbol
   addToScene: (scene) -> scene.addDOMSymbol @
 
   newInstance: () ->
-    new DOMSymbolInstance @domElement.cloneNode()
+    new DOMSymbolInstance @domElement.cloneNode(true)
 
 
 class DOMSymbolInstance extends DisplayObject
@@ -202,7 +202,7 @@ class DOMSymbolInstance extends DisplayObject
   _updatePosition: () -> @obj.matrix.fromArray @xform
 
   dispose: ()->
-    @obj.parent.remove(@obj)
+    @obj.parent?.remove(@obj)
 
 
 export symbol = (a) =>


### PR DESCRIPTION
This PR allows adding more layers to `SceneDOM` instance via public method `addLayer`. It may be used to create additional, custom layers on top of three base layers.