### PR TITLE
Bump three.js dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "basegl",
-  "version": "0.0.22",
+  "version": "0.2.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2142,6 +2142,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
       "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "optional": true,
       "requires": {
         "nan": "2.10.0",
         "node-pre-gyp": "0.6.39"
@@ -5577,7 +5578,8 @@
     "nan": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.7",
@@ -6462,6 +6464,7 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
               "requires": {
                 "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
               }
@@ -7673,9 +7676,9 @@
       }
     },
     "three": {
-      "version": "0.85.2",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.85.2.tgz",
-      "integrity": "sha1-iTb4nDZo978S+bCF3fXdQJkW6ic="
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.94.0.tgz",
+      "integrity": "sha1-TObbfyv795wtc0RKpuPPwIoy12I="
     },
     "three-effectcomposer-es6": {
       "version": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "bluebird": "^3.5.1",
     "stats.js": "^0.17.0",
-    "three": "^0.85.2",
+    "three": "^0.94.0",
     "three-effectcomposer-es6": "^0.0.4",
     "glslify-loader": "^1.0.2",
     "raw-loader": "^0.5.1",


### PR DESCRIPTION
Bumping to the newest version. The last one we have been using is quite old.