### PR TITLE
Reverse panning directions on touchpad.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2142,7 +2142,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
       "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
-      "optional": true,
       "requires": {
         "nan": "2.10.0",
         "node-pre-gyp": "0.6.39"
@@ -2288,7 +2287,6 @@
         "debug": {
           "version": "2.6.8",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -2332,7 +2330,6 @@
         "form-data": {
           "version": "2.1.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "asynckit": "0.4.0",
             "combined-stream": "1.0.5",
@@ -2412,7 +2409,6 @@
         "har-validator": {
           "version": "4.2.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ajv": "4.11.8",
             "har-schema": "1.0.5"
@@ -2524,8 +2520,7 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -2560,8 +2555,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "node-pre-gyp": {
           "version": "0.6.39",
@@ -2604,13 +2598,11 @@
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "once": {
           "version": "1.4.0",
@@ -2621,13 +2613,11 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "osenv": {
           "version": "0.1.4",
@@ -5578,8 +5568,7 @@
     "nan": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-      "optional": true
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
     },
     "nanomatch": {
       "version": "1.2.7",

--- a/src/navigation/Navigator.coffee
+++ b/src/navigation/Navigator.coffee
@@ -116,8 +116,9 @@ export class Navigator
 
     else if @action == Navigator.ACTION.PAN
       [visibleWidth, visibleHeight] = @scene.visibleSpace()
-      @desiredPos.x += movement.x * (visibleWidth  / @scene.width)
-      @desiredPos.y -= movement.y * (visibleHeight / @scene.height)
+      dir = if wheel then -1.0 else 1.0
+      @desiredPos.x -= movement.x * (visibleWidth  / @scene.width)  * dir
+      @desiredPos.y += movement.y * (visibleHeight / @scene.height) * dir
 
   onMouseDown: (event) =>
     document.addEventListener 'mousemove', @onMouseMove

--- a/src/navigation/Navigator.coffee
+++ b/src/navigation/Navigator.coffee
@@ -92,13 +92,13 @@ export class Navigator
 
   _moveCamera: (event, wheel=false) =>
     if wheel
-      movement = new Vector [-event.deltaX, -event.deltaY, 0]
+      movement = new Vector [event.deltaX, event.deltaY, 0]
     else
       movement = new Vector [event.movementX, event.movementY, 0]
 
     applyDir = (a) ->
       if wheel
-        if event.deltaY > 0 then a else a.negate()
+        if event.deltaY > 0 then a.negate() else a
       else
         if event.movementX < event.movementY then a.negate() else a
 
@@ -116,8 +116,8 @@ export class Navigator
 
     else if @action == Navigator.ACTION.PAN
       [visibleWidth, visibleHeight] = @scene.visibleSpace()
-      @desiredPos.x -= movement.x * (visibleWidth  / @scene.width)
-      @desiredPos.y += movement.y * (visibleHeight / @scene.height)
+      @desiredPos.x += movement.x * (visibleWidth  / @scene.width)
+      @desiredPos.y -= movement.y * (visibleHeight / @scene.height)
 
   onMouseDown: (event) =>
     document.addEventListener 'mousemove', @onMouseMove

--- a/src/navigation/Navigator.coffee
+++ b/src/navigation/Navigator.coffee
@@ -92,13 +92,13 @@ export class Navigator
 
   _moveCamera: (event, wheel=false) =>
     if wheel
-      movement = new Vector [event.deltaX, event.deltaY, 0]
+      movement = new Vector [-event.deltaX, -event.deltaY, 0]
     else
       movement = new Vector [event.movementX, event.movementY, 0]
 
     applyDir = (a) ->
       if wheel
-        if event.deltaY > 0 then a.negate() else a
+        if event.deltaY > 0 then a else a.negate()
       else
         if event.movementX < event.movementY then a.negate() else a
 


### PR DESCRIPTION
Now (with natural scrolling enabled) panning works like it should, i.e. like objects on the scene were laid out on a piece of paper and the two-finger drag was moving this paper. Please note that if a (Mac) user doesn't have the natural scrolling enabled, the directions will be reversed (although that's what people like @kustosz like, apparently ;))