### PR TITLE
Only update camera position if necessary

### DIFF
--- a/src/navigation/Navigator.coffee
+++ b/src/navigation/Navigator.coffee
@@ -55,6 +55,8 @@ export class Navigator
   onEveryFrame: () =>
     camDelta    = @desiredPos.sub @scene.camera.position
     camDeltaLen = camDelta.length()
+    return if camDeltaLen == 0
+
     forceVal    = camDeltaLen * @springCoeff
     force       = camDelta.normalize().mul forceVal
     force.z     = camDelta.z * @springCoeff


### PR DESCRIPTION
This should prevent the camera.move events from firing when nothing is moving.