### PR TITLE
Fix the nondeterministic touchpad detection

### DIFF
--- a/src/navigation/EventReactor.coffee
+++ b/src/navigation/EventReactor.coffee
@@ -26,18 +26,17 @@ export class EventInfo
   isCtrlMinus:        (e) => e.key == "-"  and (e.ctrlKey or e.metaKey)
   isCtrlZero:         (e) => e.key == "0"  and (e.ctrlKey or e.metaKey)
 
-  isTouchpadEvent: (e) =>
-    return unless e.type == 'wheel'
+  detectTouchpad: (e) =>
+    return unless (@isTouchPad == null) and (e.type == 'wheel')
 
     currTime = now()
-    @eventCountStart = currTime if @eventCount == 0
+    @eventCountStart ?= currTime
     @eventCount++
 
     if currTime - @eventCountStart > 100
       @isTouchPad = @eventCount > 5
       @eventCount = 0
-
-    return @isTouchPad
+      @eventCountStart = null
 
 
 ######################################################################
@@ -121,14 +120,13 @@ export class KeyboardMouseReactor extends EventReactor
 
   onWheel: (event) =>
     event.preventDefault()
-    isTouchPad = @eventInfo.isTouchpadEvent event
-    console.log "isTouchPad: ", isTouchPad
-    return if isTouchPad == null
+    @eventInfo.detectTouchpad event
+    return if @eventInfo.isTouchPad == null
 
     movement = Movement.fromEvent event
     @navigator.calcCameraPath movement
 
-    if isTouchPad
+    if @eventInfo.isTouchPad
       if event.ctrlKey
         # ctrl + wheel is how the trackpad-pinch is represented
         @navigator.zoom movement

--- a/src/navigation/Navigator.coffee
+++ b/src/navigation/Navigator.coffee
@@ -87,8 +87,8 @@ export class Navigator
 
   # Move the camera to a given point.
   moveTo: (coords) =>
-    @desiredPos.x = coords2.x if coords.x?
-    @desiredPos.y = coords2.y if coords.y?
-    @desiredPos.z = coords2.z if coords.z?
+    @desiredPos.x = coords.x if coords.x?
+    @desiredPos.y = coords.y if coords.y?
+    @desiredPos.z = coords.z if coords.z?
 
     @pan (new Movement)


### PR DESCRIPTION
Ugh, the dynamic detection of touchpad vs. the mouse turned out to be not very reliable. This fixes the weird behaviour by fixing the choice once its determined. Please note that there still is one way to break it:
two-finger drag on the touchpad REALLLLLY slow -- then it thinks it's mouse :( That said, you really need to be precise to achieve that.